### PR TITLE
Fix/generate assets

### DIFF
--- a/Generator/DefaultSiteGenerator.php
+++ b/Generator/DefaultSiteGenerator.php
@@ -56,9 +56,9 @@ class DefaultSiteGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Gene
             'prefix'            => $prefix
         );
 
-        #$this->generateEntities($bundle, $parameters, $output);
-        #$this->generateForm($bundle, $parameters, $output);
-        #$this->generateFixtures($bundle, $parameters, $output);
+        $this->generateEntities($bundle, $parameters, $output);
+        $this->generateForm($bundle, $parameters, $output);
+        $this->generateFixtures($bundle, $parameters, $output);
         $this->generateAssets($bundle, $output);
         // CAUTION : Following templates change the skeleton dir array
         // TODO Find a better way


### PR DESCRIPTION
When generating the assets use the mirror function to copy all files and dirs recursive to the correct destination. No more using an array to specify the files, because if a file is moved or a new one is created it will not copy it.
