### PR TITLE
uppercase first letter entity

### DIFF
--- a/Command/GenerateArticleCommand.php
+++ b/Command/GenerateArticleCommand.php
@@ -63,7 +63,7 @@ EOT
 
         $namespace = Validators::validateBundleNamespace($input->getOption('namespace'));
         $bundle = strtr($namespace, array('\\' => ''));
-        $entity = $input->getOption('entity');
+        $entity = ucfirst($input->getOption('entity'));
 
         $prefix = $input->getOption('prefix');
         $bundle = $this


### PR DESCRIPTION
This will uppercase the first letter of the entity. So is you type in news as entity name it will still generate a News entity.
