### PR TITLE
escape entity name

### DIFF
--- a/Resources/SensioGeneratorBundle/skeleton/article/AdminList/AuthorAdminListConfigurator.php
+++ b/Resources/SensioGeneratorBundle/skeleton/article/AdminList/AuthorAdminListConfigurator.php
@@ -28,7 +28,7 @@ class {{ entity_class }}AuthorAdminListConfigurator extends AbstractArticleAutho
      */
     public function getEntityName()
     {
-        return "{{ entity_class }}\{{ entity_class }}Author";
+        return "{{ entity_class }}\\{{ entity_class }}Author";
     }
 
 }

--- a/Resources/SensioGeneratorBundle/skeleton/article/AdminList/PageAdminListConfigurator.php
+++ b/Resources/SensioGeneratorBundle/skeleton/article/AdminList/PageAdminListConfigurator.php
@@ -29,7 +29,7 @@ class {{ entity_class }}PageAdminListConfigurator extends AbstractArticlePageAdm
      */
     public function getEntityName()
     {
-        return "{{ entity_class }}\{{ entity_class }}Page";
+        return "{{ entity_class }}\\{{ entity_class }}Page";
     }
 
     /**


### PR DESCRIPTION
Escape the entity_class otherwise if the entity start with n it will become \n and becomes a new line and then the routers will not work anymore.
