### PR TITLE
Fallback to the defaultlocale

### DIFF
--- a/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
+++ b/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace {{ namespace }}\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route,
+    Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class DefaultController extends Controller
+{
+
+}

--- a/Resources/SensioGeneratorBundle/skeleton/defaultsite/EventListener/DefaultLocaleListener.php
+++ b/Resources/SensioGeneratorBundle/skeleton/defaultsite/EventListener/DefaultLocaleListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace {{ namespace }}\EventListener;
+
+
+use Symfony\Component\HttpFoundation\RedirectResponse,
+    Symfony\Component\HttpKernel\Event\FilterResponseEvent,
+    Symfony\Component\HttpFoundation\Request;
+
+class DefaultLocaleListener {
+
+    private $defaultLocale;
+    public function __construct($defaultLocale)
+    {
+        $this->defaultLocale = $defaultLocale;
+    }
+
+    /**
+     * If the response is a 404 and the URL is the root then redirect to the language root of the defaultlanguage.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event) {
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+
+        // When we're on root and it's NOT succesful, redirect to the root for the defaultLocale.
+        if (($this->isRootUrl($request)) && !$response->isSuccessful()) {
+            $response = new RedirectResponse($request->getBaseUrl() . '/' . $this->defaultLocale);
+            $event->setResponse($response);
+        }
+    }
+
+    private function isRootUrl(Request $request)
+    {
+        $url = $request->getPathInfo();
+        return (empty($url) || ($url == '/'));
+    }
+
+
+}

--- a/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/config/services.yml
+++ b/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/config/services.yml
@@ -1,0 +1,6 @@
+services:
+  ~~~APPNAME~~~.default_locale_listener:
+    class: ~~~NAMESPACE~~~\EventListener\DefaultLocaleListener
+    tags:
+      - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+    arguments: [%defaultlocale%]


### PR DESCRIPTION
The problem is that when you run the BundleGenerator it installs a simple DefaultController with a template. When you run the DefaultSite generator it only enables the site on the /en URL. Everything else still simply shows the DefaultController's action.

So I removed the action in the DefaultController, added a listener which detects failed responses on the root URL which redirects to the root URL for the default locale.

See issue: https://github.com/Kunstmaan/KunstmaanSandbox/issues/90
