### PR TITLE
Fix/behat multi single lang

### DIFF
--- a/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
+++ b/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
@@ -29,8 +29,8 @@ class FeatureContext extends AbstractContext
     {
         $this->parameters = $parameters;
 
-        if ($this->parameters['multilanguage']) {
-            $this->lang = "/".$this->parameters['language'];
+        if ($this->parameters['language'] === 'multi') {
+            $this->lang = "/en";
         }
 
         // Load Context Class


### PR DESCRIPTION
use a context parameter to determine if the site is multi or single language in the behat tests.
