### PR TITLE
Fix behat specificpage 2.3

### DIFF
--- a/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
+++ b/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
@@ -229,7 +229,7 @@ class FeatureContext extends AbstractContext
         //Only activate the filter module if it is not an additionally filter
         if (!$additionally) {
             $selector = new CssSelector();
-            $this->getSession()->getPage()->find("xpath", $selector->translateToXPath('div.iPhoneCheckHandle'))->click();
+            $this->findAndClickButton($this->getSession()->getPage(), 'xpath', $selector->translateToXPath('div.iPhoneCheckHandle'));
         }
 
         $records = $this->createFilterRecords($filterType, $filterComparator, $filterValue, $additionally);


### PR DESCRIPTION
Fix so behat will not crash if it cannot activate the filter module.
