### PR TITLE
Fix snake_casing of columnnames for the EntityGenerator

### DIFF
--- a/Command/GenerateEntityCommand.php
+++ b/Command/GenerateEntityCommand.php
@@ -319,6 +319,8 @@ EOT
                 $defaultType = 'boolean';
             }
 
+            $columnName = DoctrineEntityGenerator::convertCamelCaseToSnakeCase($columnName);
+
             $type = $dialog->askAndValidate($output, $dialog->getQuestion('Field type', $defaultType), $fieldValidator, false, $defaultType, $types);
 
             $data = array('columnName' => $columnName, 'fieldName' => lcfirst(Container::camelize($columnName)), 'type' => $type);

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -92,7 +92,7 @@ class DoctrineEntityGenerator extends Generator
         return $this->convertCamelCaseToSnakeCase($entityName);
     }
 
-    private function convertCamelCaseToSnakeCase($text)
+    public static function convertCamelCaseToSnakeCase($text)
     {
         $text = preg_replace_callback('/[A-Z]/', create_function('$match', 'return "_" . strtolower($match[0]);'), $text);
         // remove first underscore.


### PR DESCRIPTION
Correctly follows Kuma conventions for the columns.
