### PR TITLE
lowercase route when generating bundle

### DIFF
--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -92,10 +92,10 @@ class BundleGenerator extends Generator
 
         $basename = substr($bundle, 0, -6);
         $parameters = array(
-            'namespace'         => $namespace,
-            'bundle'            => $bundle,
-            'bundle_basename'   => $basename,
-            'extension_alias'   => Container::underscore($basename),
+            'namespace'       => $namespace,
+            'bundle'          => $bundle,
+            'bundle_basename' => $basename,
+            'extension_alias' => Container::underscore($basename),
         );
 
         $this->renderFile('/bundle/Bundle.php', $dir . '/' . $bundle . '.php', $parameters);


### PR DESCRIPTION
This will make the _default in routing all lowercase when generating a new bundle.
