### PR TITLE
add entity name to menu adaptor service name

### DIFF
--- a/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/services.yml
+++ b/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/services.yml
@@ -1,6 +1,5 @@
 
-
-    {{ bundle.getName()|lower }}.menu.adaptor:
+    {{ bundle.getName()|lower }}.{{ entity_class|lower }}.menu.adaptor:
         class: {{ namespace }}\Helper\Menu\{{ entity_class }}MenuAdaptor
         arguments: ["@doctrine.orm.entity_manager"]
         tags:


### PR DESCRIPTION
This will add the entity name to the service name for the menu adaptor. Otherwise if you add multiple articles to your bundle the services will all have the same name and only the last one will work.
