### PR TITLE
Fix deprecated function calls

### DIFF
--- a/Generator/KunstmaanGenerator.php
+++ b/Generator/KunstmaanGenerator.php
@@ -79,13 +79,13 @@ class KunstmaanGenerator extends Generator
     protected function generateEntity(BundleInterface $bundle, $name, $fields, $namePrefix, $dbPrefix, $extendClass = null)
     {
         // configure the bundle (needed if the bundle does not contain any Entities yet)
-        $config = $this->registry->getEntityManager(null)->getConfiguration();
+        $config = $this->registry->getManager(null)->getConfiguration();
         $config->setEntityNamespaces(array_merge(
             array($bundle->getName() => $bundle->getNamespace().'\\Entity\\'.$namePrefix),
             $config->getEntityNamespaces()
         ));
 
-        $entityClass = $this->registry->getEntityNamespace($bundle->getName()).'\\'.$namePrefix.'\\'.$name;
+        $entityClass = $this->registry->getAliasNamespace($bundle->getName()).'\\'.$namePrefix.'\\'.$name;
         $entityPath = $bundle->getPath().'/Entity/'.$namePrefix.'/'.str_replace('\\', '/', $name).'.php';
         if (file_exists($entityPath)) {
             throw new \RuntimeException(sprintf('Entity "%s" already exists.', $entityClass));


### PR DESCRIPTION
Resolves:

Deprecated: getEntityManager is deprecated since Symfony 2.1. Use getManager instead in /home/projects/coronadirect/data/coronadirect/vendor/doctrine/doctrine-bundle/Doctrine/Bundle/DoctrineBundle/Registry.php on line 71

PHP Deprecated:  getEntityNamespace is deprecated since Symfony 2.1. Use getAliasNamespace instead in /home/projects/coronadirect/data/coronadirect/vendor/doctrine/doctrine-bundle/Doctrine/Bundle/DoctrineBundle/Registry.php on line 129
