### PR TITLE
Prefix should not be a required option

### DIFF
--- a/Command/GenerateEntityCommand.php
+++ b/Command/GenerateEntityCommand.php
@@ -85,7 +85,7 @@ EOT
             }
         }
 
-        GeneratorUtils::ensureOptionsProvided($input, array('entity', 'fields', 'prefix'));
+        GeneratorUtils::ensureOptionsProvided($input, array('entity', 'fields'));
 
         $entityInput = Validators::validateEntityName($input->getOption('entity'));
         list($bundleName, $entity) = $this->parseShortcutNotation($entityInput);


### PR DESCRIPTION
kuma:generate:entity --prefix is optional, but it is validated as if it's required.