### PR TITLE
Fixed pagepart generation

### DIFF
--- a/Generator/PagePartGenerator.php
+++ b/Generator/PagePartGenerator.php
@@ -76,7 +76,7 @@ class PagePartGenerator extends KunstmaanGenerator
      */
     private function generatePagePartEntity()
     {
-	if ($this->bundle->getPath().'/Entity/PageParts/AbstractPagePart.php') {
+	if (file_exists($this->bundle->getPath().'/Entity/PageParts/AbstractPagePart.php')) {
 	    $abstractClass = $this->bundle->getNamespace().'\Entity\PageParts\AbstractPagePart';
 	} else {
 	    $abstractClass = 'Kunstmaan\PagePartBundle\Entity\AbstractPagePart';


### PR DESCRIPTION
When generating a pagepart using Kunstmaan v3.1 the check for an AbstractPagePart only contained a string and did not check if the file existed which resulted in an error when trying to generate a pagepart.